### PR TITLE
Update Core-v3.0.ps1

### DIFF
--- a/Core-v3.0.ps1
+++ b/Core-v3.0.ps1
@@ -159,8 +159,8 @@ Function NPMCycle {
         $Variables.LastDonated = Get-Date
         $Variables.DonateRandom = [PSCustomObject]@{}
     }
-    Update-Status("Loading BTC rate from 'api.coinbase.com'..")
-    $Rates = Invoke-RestMethod "https://api.coinbase.com/v2/exchange-rates?currency=BTC" -UseBasicParsing | Select-Object -ExpandProperty data | Select-Object -ExpandProperty rates
+    Update-Status("Loading $($Config.Passwordcurrency) rate from 'api.coinbase.com'..")
+    $Rates = Invoke-RestMethod "https://api.coinbase.com/v2/exchange-rates?currency=$($Config.Passwordcurrency)" -UseBasicParsing | Select-Object -ExpandProperty data | Select-Object -ExpandProperty rates
     $Config.Currency | Where-Object {$Rates.$_} | ForEach-Object {$Rates | Add-Member $_ ([Double]$Rates.$_) -Force}
     $Variables | Add-Member -Force @{Rates = $Rates}
     #Load the Stats
@@ -419,7 +419,7 @@ Function NPMCycle {
             ) | Out-Host
         }
     }
-    Write-Host "      1BTC = $($Variables.Rates.($Config.Currency)) $($Config.Currency)"
+    Write-Host "      1$($Config.Passwordcurrency) = $($Variables.Rates.($Config.Currency)) $($Config.Currency)"
     # Get and display earnings stats
     $Variables.EarningsTrackerJobs | ? {$_.state -eq "Running"} | foreach {
         $EarnTrack = $_ | Receive-Job


### PR DESCRIPTION
I am using Zergpool and mining to LTC instead of BTC as LTC is the other payment coin guaranteed by the pool. I made a few changes shown here to show the proper conversion prices. I was going to make more changes but I don't fully understand the implications of changing this across the board. My main concern is that it is going to screw up the plus brain data due to the difference in expected BTC versus the actual LTC I receive. I know it messes with the expected payout date which doesn't bother me but I hope the plus data is still effective.