### PR TITLE
EWBF miner: add maximum intensity via --intensity

### DIFF
--- a/Miners/EWBF.ps1
+++ b/Miners/EWBF.ps1
@@ -40,7 +40,7 @@ $Commands | Get-Member -MemberType NoteProperty | Select -ExpandProperty Name | 
     [PSCustomObject]@{
         Type = "NVIDIA"
         Path = $Path
-        Arguments = "--api 127.0.0.1:$($Variables.MinerAPITCPPort) --server $($Pools.(Get-Algorithm($_)).Host) --port $($Pools.(Get-Algorithm($_)).Port) --fee 0 --solver 0 --eexit 1 --user $($Pools.(Get-Algorithm($_)).User) --pass $($Pools.(Get-Algorithm($_)).Pass)$($Commands.$_)"
+        Arguments = "--api 127.0.0.1:$($Variables.MinerAPITCPPort) --server $($Pools.(Get-Algorithm($_)).Host) --port $($Pools.(Get-Algorithm($_)).Port) --fee 0 --solver 0 --eexit 1 --user $($Pools.(Get-Algorithm($_)).User) --pass $($Pools.(Get-Algorithm($_)).Pass)$($Commands.$_) --intensity 64"
         HashRates = [PSCustomObject]@{(Get-Algorithm($_)) = $Stats."$($Name)_$(Get-Algorithm($_))_HashRate".Week}
         API = "EWBF"
         Port =  $Variables.MinerAPITCPPort


### PR DESCRIPTION
Q: How intensity works? 
A: The miner uses adaptive intensity and tries to use the maximum intensity value, with the help of the --intensity option you can set a limit on the maximum intensity, this will slightly reduce gpu usage and performance. Allowed values 1 - 64. You can set different values for each cards --intensity 64 64 64 64