### PR TITLE
Claymore's Dual Ethereum Miner: use NVIDIA GPUs only

### DIFF
--- a/Miners/EthashClaymore.ps1
+++ b/Miners/EthashClaymore.ps1
@@ -12,7 +12,7 @@ $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty 
     [PSCustomObject]@{
         Type = "NVIDIA"
         Path = $Path
-        Arguments = " -esm 3 -allpools 1 -allcoins 1 -platform 3 -mport -$($Variables.MinerAPITCPPort) -epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass)$($Commands.$_)"
+        Arguments = " -esm 3 -allpools 1 -allcoins 1 -platform 2 -mport -$($Variables.MinerAPITCPPort) -epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass)$($Commands.$_)"
         HashRates = [PSCustomObject]@{(Get-Algorithm($_)) = $Stats."$($Name)_$(Get-Algorithm($_))_HashRate".Week * .99} # substract 1% devfee
         API = "Claymore"
         Port = $Variables.MinerAPITCPPort #3333


### PR DESCRIPTION
Because NemosMiner is for NVIDIA.
> -platform   selects GPUs manufacturer. 1 - use AMD GPUs only. 2 - use NVIDIA GPUs only. 3 - use both AMD and NVIDIA GPUs. Default value is "3".