### PR TITLE
Default donation minutes is 8

### DIFF
--- a/Core-v3.1.ps1
+++ b/Core-v3.1.ps1
@@ -41,10 +41,10 @@ Function InitApplication {
     #Update stats with missing data and set to today's date/time
     if (Test-Path "Stats") {Get-ChildItemContent "Stats" | ForEach {$Stat = Set-Stat $_.Name $_.Content.Week}}
     #Set donation parameters
-    #Randomly sets donation minutes per day between (0,(3..5)) minutes if set to less than 3
+    #Randomly sets donation minutes per day between (0,(3..8)) minutes if set to less than 3
     $Variables | Add-Member -Force @{DonateRandom = [PSCustomObject]@{}}
     $Variables | Add-Member -Force @{LastDonated = (Get-Date).AddDays(-1).AddHours(1)}
-    If ($Config.Donate -lt 3) {$Config.Donate = (0, (3..5)) | Get-Random}
+    If ($Config.Donate -lt 3) {$Config.Donate = (0, (3..8)) | Get-Random}
     $Variables | Add-Member -Force @{WalletBackup = $Config.Wallet}
     $Variables | Add-Member -Force @{UserNameBackup = $Config.UserName}
     $Variables | Add-Member -Force @{WorkerNameBackup = $Config.WorkerName}


### PR DESCRIPTION
If donation set to less than 3, randomly sets donation minutes between minimum (3) and default (8) per day.
Based on #553