### PR TITLE
Add recommended maximum intensity for Vitality

### DIFF
--- a/OptionalMiners/enemyzealot1.09.ps1
+++ b/OptionalMiners/enemyzealot1.09.ps1
@@ -41,7 +41,7 @@ $Commands = [PSCustomObject]@{
     #"veltor" = "" #Veltor
     #"x11evo" = " -d $SelGPUCC" #X11evo
     "x17" = " -i 20 -d $SelGPUCC" #X17(Alexis78 and enemy 1.03 faster)
-    "vitalium" = " -d $SelGPUCC" #Vitalium
+    "vitalium" = " -i 21 -d $SelGPUCC" #Vitalium
     #"yescrypt" = "" #Yescrypt
 }
 


### PR DESCRIPTION
> - Support new algos : Xevan (-a xevan) and Vitality (-a vit), recommended intensity for Xevan 19-20, for Vitality 19-21
[source](https://bitcointalk.org/index.php?topic=3378390.0)