### PR TITLE
Bminer: add support for using GPU IDs

### DIFF
--- a/OptionalMiners/Bminer.ps1
+++ b/OptionalMiners/Bminer.ps1
@@ -4,7 +4,7 @@ $Path = ".\Bin\NVIDIA-Bminer\bminer.exe"
 $Uri = "https://www.bminercontent.com/releases/bminer-lite-v8.0.0-32928c5-amd64.zip"
 
 $Commands = [PSCustomObject]@{
-    "equihash" = "" #Equihash(fastest 2% dev fee)
+    "equihash" = " -devices $SelGPUCC" #Equihash(fastest 2% dev fee)
 }
 $Port = "1880"
 $Name = (Get-Item $script:MyInvocation.MyCommand.Path).BaseName
@@ -13,7 +13,7 @@ $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty 
     [PSCustomObject]@{
         Type = "NVIDIA"
         Path = $Path
-        Arguments = " -api 127.0.0.1:$Port -uri stratum://$($Pools.(Get-Algorithm($_)).User).$($Pools.(Get-Algorithm($_)).Pass)@$($Pools.(Get-Algorithm($_)).Host):$($Pools.(Get-Algorithm($_)).Port)"
+        Arguments = " -api 127.0.0.1:$Port -uri stratum://$($Pools.(Get-Algorithm($_)).User).$($Pools.(Get-Algorithm($_)).Pass)@$($Pools.(Get-Algorithm($_)).Host):$($Pools.(Get-Algorithm($_)).Port)$($Commands.$_)"
         HashRates = [PSCustomObject]@{(Get-Algorithm($_)) = $Stats."$($Name)_$(Get-Algorithm($_))_HashRate".Week * .98} # substract 2% devfee
         API = "Wrapper"
         Port = "1880"


### PR DESCRIPTION
-devices value
List of comma-separated IDs of the CUDA devices that Bminer should run on. If it is unspecified bminer runs on all CUDA devices available on the system.