### PR TITLE
PhoenixMiner native command-line arguments

### DIFF
--- a/Miners/EthashPhoenix.ps1
+++ b/Miners/EthashPhoenix.ps1
@@ -12,7 +12,7 @@ $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty 
     [PSCustomObject]@{
         Type = "NVIDIA"
         Path = $Path
-        Arguments = "-esm 3 -allpools 1 -allcoins 1 -platform 2 -mport -$($Variables.NVIDIAMinerAPITCPPort) -epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass)$($Commands.$_)"
+        Arguments = "-rmode 0 -proto 4 -coin auto -nvidia -cdmport -$($Variables.NVIDIAMinerAPITCPPort) -pool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -wal $($Pools.Ethash.User) -pass $($Pools.Ethash.Pass)$($Commands.$_)"
         HashRates = [PSCustomObject]@{(Get-Algorithm($_)) = $Stats."$($Name)_$(Get-Algorithm($_))_HashRate".Week * .9935} # substract 0.65% devfee
         API = "Wrapper"
         Port = $Variables.NVIDIAMinerAPITCPPort #3333


### PR DESCRIPTION
Some explanation:
-rmode 0: miner will shut down instead of restarting
-proto 4: EthereumStratum/1.0.0 (e.g. nicehash)
-coin auto: Ethash coin to use for devfee to avoid switching DAGs
-nvidia: Use only Nvidia cards