### PR TITLE
Kill miners by path to prevent duplicate miners running

### DIFF
--- a/Core.ps1
+++ b/Core.ps1
@@ -411,6 +411,9 @@ Function NPMCycle {
         if ($filtered.Count -eq 0) {
             if ($_.Process -eq $null) {
                 $_.Status = "Failed"
+                # Try to kill any process with the same path, in case it is still running but the process handle is incorrect
+                $KillPath = $_.Path
+                Get-Process | Where-Object {$_.Path -eq $KillPath} | Stop-Process -Force
             }
             elseif ($_.Process.HasExited -eq $false) {
                 $_.Active += (Get-Date) - $_.Process.StartTime
@@ -418,6 +421,10 @@ Function NPMCycle {
                 Sleep 1
                 # simply "Kill with power"
                 Stop-Process $_.Process -Force | Out-Null
+                Sleep 1
+                # Kill any process with the same path, in case $_.Process is incorrect
+                $KillPath = $_.Path
+                Get-Process | Where-Object {$_.Path -eq $KillPath} | Stop-Process -Force
                 $Variables.StatusText = "closing current miner and switching"
                 Sleep 1
                 $_.Status = "Idle"

--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -1224,6 +1224,9 @@ $ButtonPause.Add_Click( {
                             Sleep 1
                             # simply "Kill with power"
                             Stop-Process $_.Process -Force | Out-Null
+                            # Try to kill any process with the same path, in case it is still running but the process handle is incorrect
+                            $KillPath = $_.Path
+                            Get-Process | Where-Object {$_.Path -eq $KillPath} | Stop-Process -Force
                             Write-Host -ForegroundColor Yellow "closing miner"
                             Sleep 1
                             $_.Status = "Idle"

--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -454,6 +454,9 @@ $MainForm.Add_FormClosing( {
                         Sleep 1
                         # simply "Kill with power"
                         Stop-Process $_.Process -Force | Out-Null
+                        # Try to kill any process with the same path, in case it is still running but the process handle is incorrect
+                        $KillPath = $_.Path
+                        Get-Process | Where-Object {$_.Path -eq $KillPath} | Stop-Process -Force
                         Write-Host -ForegroundColor Yellow "closing miner"
                         Sleep 1
                         $_.Status = "Idle"

--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -1308,6 +1308,9 @@ $ButtonStart.Add_Click( {
                             Sleep 1
                             # simply "Kill with power"
                             Stop-Process $_.Process -Force | Out-Null
+                            # Try to kill any process with the same path, in case it is still running but the process handle is incorrect
+                            $KillPath = $_.Path
+                            Get-Process | Where-Object {$_.Path -eq $KillPath} | Stop-Process -Force
                             Write-Host -ForegroundColor Yellow "closing miner"
                             Sleep 1
                             $_.Status = "Idle"


### PR DESCRIPTION
Ran into this issue on one of my machines - happened twice in 72 hours of mining, so not very often, but when it did happen it really messed up my stats, making it think trex balloon was mining at 11MH/s.

In rare cases, particularly on systems with low end CPUs that are laggy when mining, the process handle for a miner can be incorrect. This causes a miner to appear to have exited or failed even though it is still running.

When the miner is restarted, or a new miner started, the old one will still be mining, and worse listening on that port, so the new miner's stats will get messed up.

Adds a couple extra lines to find such miners by their path and kill them even if the process handle is incorrect.