### PR TITLE
Only show date for estimated pay date

### DIFF
--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -154,7 +154,7 @@ Function Form_Load {
                             # @{Name="Unpaid";Expression={$_.total_unpaid}},
                             @{Name = "BTC/D"; Expression = {"{0:N8}" -f ($_.BTCD)}},
                             @{Name = "mBTC/D"; Expression = {"{0:N3}" -f ($_.BTCD * 1000)}},
-                            @{Name = "Est. Pay Date"; Expression = {$_.EstimatedPayDate}},
+                            @{Name = "Est. Pay Date"; Expression = {if($_.EstimatedPayDate -is 'DateTime') {$_.EstimatedPayDate.ToShortDateString()} else {$_.EstimatedPayDate}}},
                             @{Name = "PaymentThreshold"; Expression = {"$($_.PaymentThreshold) ($('{0:P0}' -f $($_.Balance / $_.PaymentThreshold)))"}},
                             @{Name = "Wallet"; Expression = {$_.Wallet}}
                         ) | Sort "BTC/D" -Descending)

--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -154,7 +154,7 @@ Function Form_Load {
                             # @{Name="Unpaid";Expression={$_.total_unpaid}},
                             @{Name = "BTC/D"; Expression = {"{0:N8}" -f ($_.BTCD)}},
                             @{Name = "mBTC/D"; Expression = {"{0:N3}" -f ($_.BTCD * 1000)}},
-                            @{Name = "Est. Pay Date"; Expression = {if($_.EstimatedPayDate -is 'DateTime') {$_.EstimatedPayDate.ToShortDateString()} else {$_.EstimatedPayDate}}},
+                            @{Name = "Est. Pay Date"; Expression = {if ($_.EstimatedPayDate -is 'DateTime') {$_.EstimatedPayDate.ToShortDateString()} else {$_.EstimatedPayDate}}},
                             @{Name = "PaymentThreshold"; Expression = {"$($_.PaymentThreshold) ($('{0:P0}' -f $($_.Balance / $_.PaymentThreshold)))"}},
                             @{Name = "Wallet"; Expression = {$_.Wallet}}
                         ) | Sort "BTC/D" -Descending)


### PR DESCRIPTION
Time gets cut off, and isn't accurate anyways since it won't take into
account the time the pool actually does payouts.