### PR TITLE
Fix 0 being shown as 0 PH/s instead of 0 H/s

### DIFF
--- a/Include.ps1
+++ b/Include.ps1
@@ -685,6 +685,7 @@ function Get-HashRate {
 filter ConvertTo-Hash { 
     $Hash = $_
     switch ([math]::truncate([math]::log($Hash, [Math]::Pow(1000, 1)))) {
+        "-Infinity" {"0  H"}
         0 {"{0:n2}  H" -f ($Hash / [Math]::Pow(1000, 0))}
         1 {"{0:n2} KH" -f ($Hash / [Math]::Pow(1000, 1))}
         2 {"{0:n2} MH" -f ($Hash / [Math]::Pow(1000, 2))}


### PR DESCRIPTION
For 0, the [math] functions return [double]::NegativeInfinity.
Switch converts it to a string as "-Infinity"

Since that doesn't match any of the cases, 0 always got reported as the
default of PH/s.