### PR TITLE
Fix region bug

### DIFF
--- a/Include.ps1
+++ b/Include.ps1
@@ -158,7 +158,7 @@ Function Update-Monitoring {
         }
         $DataJSON = ConvertTo-Json @($Data)
         # Calculate total estimated profit
-        $Profit = ([Math]::Round(($data | Measure-Object Profit -Sum).Sum, 8)).ToString()
+        $Profit = [string]([Math]::Round(($data | Measure-Object Profit -Sum).Sum, 8))
 
         # Send the request
         $Body = @{user = $Config.MonitoringUser; worker = $Config.WorkerName; version = $Version; status = $Status; profit = $Profit; data = $DataJSON}


### PR DESCRIPTION
Using .toString() localizes the number, putting commas for decimal separator if that's what the region the computer is set to uses.

using '[string] $variable' uses the region neutral settings, always using period.

Fixes #837 