### PR TITLE
GNU General Public License v3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ https://nemosminer.com
 Updated 11 November 2018
 
 [![Version tag](https://img.shields.io/github/release/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/releases/latest) [![Version date tag](https://img.shields.io/github/release-date/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/Nemosminer/releases/latest) [![Issues tag](https://img.shields.io/github/issues-raw/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/issues)
+[![GitHub license](https://img.shields.io/github/license/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/blob/master/LICENSE)
 ![Releases](https://img.shields.io/github/downloads/nemosminer/NemosMiner/total.svg)
+[![Github All Releases](https://img.shields.io/github/downloads/nemosminer/NemosMiner/total.svg)](https://github.com/nemosminer/NemosMiner/releases)
 
 by Nemo/Minerx117
 
@@ -217,5 +219,5 @@ Some miners do not support more that 9 cards
 
 *****
 
-Licensed under the GNU General Public License v3.1
+Licensed under the GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/nemosminer/NemosMiner/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Updated 11 November 2018
 [![Version tag](https://img.shields.io/github/release/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/releases/latest) [![Version date tag](https://img.shields.io/github/release-date/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/Nemosminer/releases/latest) [![Issues tag](https://img.shields.io/github/issues-raw/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/issues)
 [![GitHub license](https://img.shields.io/github/license/nemosminer/NemosMiner.svg)](https://github.com/nemosminer/NemosMiner/blob/master/LICENSE)
 ![Releases](https://img.shields.io/github/downloads/nemosminer/NemosMiner/total.svg)
-[![Github All Releases](https://img.shields.io/github/downloads/nemosminer/NemosMiner/total.svg)](https://github.com/nemosminer/NemosMiner/releases)
 
 by Nemo/Minerx117
 


### PR DESCRIPTION
nemosminer/NemosMiner is licensed under the

GNU General Public License v3.0
Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.