### PR TITLE
Catch convertfrom-json errors

### DIFF
--- a/Include.ps1
+++ b/Include.ps1
@@ -486,12 +486,17 @@ function Get-ChildItemContent {
 
     $ChildItems = Get-ChildItem -Recurse -Path $Path -Include $Include | ForEach-Object {
         $Name = $_.BaseName
+        $FileName = $_.Name
         $Content = @()
         if ($_.Extension -eq ".ps1") {
             $Content = &$_.FullName
         }
         else {
-            $Content = $_ | Get-Content | ConvertFrom-Json
+            Try {
+                $Content = $_ | Get-Content | ConvertFrom-Json
+            } Catch {
+                Write-Host "Unable to load $Path\$FileName"
+            }
         }
         $Content | ForEach-Object {
             [PSCustomObject]@{Name = $Name; Content = $_}


### PR DESCRIPTION
The errors people are sometimes seeing right after Initializing Variables in the console are usually caused by stats files that are empty.

This catches the error and shows what file it is, just in case there are actual errors in the stats files.  They can generally be ignored though.