### PR TITLE
Remove Gminer temperature limits, this only applies to the first card

### DIFF
--- a/OptionalMiners/Gminer.ps1
+++ b/OptionalMiners/Gminer.ps1
@@ -21,7 +21,7 @@ $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty 
     [PSCustomObject]@{
         Type      = "NVIDIA"
         Path      = $Path
-        Arguments = "-t 95 --watchdog 0 --api $($Variables.NVIDIAMinerAPITCPPort) --server $($Pools.($Algo).Host) --port $($Pools.($Algo).Port) --user $($Pools.($Algo).User) --pass $($Pools.($Algo).Pass)$($Commands.$_)"
+        Arguments = "--watchdog 0 --api $($Variables.NVIDIAMinerAPITCPPort) --server $($Pools.($Algo).Host) --port $($Pools.($Algo).Port) --user $($Pools.($Algo).User) --pass $($Pools.($Algo).Pass)$($Commands.$_)"
         HashRates = [PSCustomObject]@{($Algo) = $Stats."$($Name)_$($Algo)_HashRate".Day * .98} # substract 2% devfee
         API       = "gminer"
         Port      = $Variables.NVIDIAMinerAPITCPPort


### PR DESCRIPTION
Proper settings would be: `-t 95 95 95 95 95 95` ...

Single `--templimit 95` settings only works for EWBF.